### PR TITLE
Transform modified task's result JToken to be dynamic

### DIFF
--- a/Frends.JSON.Transform/CHANGELOG.md
+++ b/Frends.JSON.Transform/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1] - 2022-10-31
+### Fixed
+- Changed the Result JToken to be dynamic to enable dot notation
+- Changed input parameter field default DataFormatString to Json
+- Updated documentation
+- Fixed tests
+
 ## [1.0.0] - 2022-04-06
 ### Added
 - Initial implementation

--- a/Frends.JSON.Transform/Frends.JSON.Transform.Tests/UnitTests.cs
+++ b/Frends.JSON.Transform/Frends.JSON.Transform.Tests/UnitTests.cs
@@ -3,122 +3,124 @@ using System;
 using Newtonsoft.Json.Linq;
 using Frends.JSON.Transform.Definitions;
 
-namespace Frends.JSON.Transform.Tests
+namespace Frends.JSON.Transform.Tests;
+
+[TestFixture]
+class TestClass
 {
-    [TestFixture]
-    class TestClass
+    Input _testInput;
+    private const string _testJson =
+@"
+{
+""firstName"": ""Veijo"",
+""lastName"": ""Frends"",
+""age"": 30,
+""retired"": false
+}
+";
+    private const string _testMap =
+@"
+{
+""FullName"": ""#xconcat(#valueof($.firstName), ,#valueof($.lastName))"",
+""Age"" : ""#valueof($.age)"",
+""StillBreething"": ""#valueof($.retired)""
+}
+";
+    [SetUp]
+    public void TestSetup()
     {
-        Input _testInput;
-        private const string _testJson =
-@"
-{
-    ""firstName"": ""Veijo"",
-    ""lastName"": ""Frends"",
-    ""age"": 30,
-    ""retired"": false
-}
-";
-        private const string _testMap =
-@"
-{
-    ""FullName"": ""#xconcat(#valueof($.firstName), ,#valueof($.lastName))"",
-    ""Age"" : ""#valueof($.age)"",
-    ""StillBreething"": ""#valueof($.retired)""
-}
-";
-        [SetUp]
-        public void TestSetup()
+        _testInput = new Input
         {
-            _testInput = new Input
-            {
-                InputJson = _testJson,
-                JsonMap = _testMap
-            };
-        }
+            InputJson = _testJson,
+            JsonMap = _testMap
+        };
+    }
 
-        [Test]
-        public void TransformShouldAllowJTokenAsInput()
-        {
-            _testInput.InputJson = JToken.Parse(_testJson);
-            var result = JSON.Transform(_testInput);
-        }
+    [Test]
+    public void TransformShouldAllowJTokenAsInput()
+    {
+        _testInput.InputJson = JToken.Parse(_testJson);
+        var result = JSON.Transform(_testInput);
+        Assert.AreEqual("{\"FullName\":\"Veijo Frends\",\"Age\":30,\"StillBreething\":false}", result.Transformation);
+    }
 
-        [Test]
-        public void TransformShouldAllowStringAsInput()
-        {
-            var result = JSON.Transform(_testInput);
-        }
+    [Test]
+    public void TransformShouldAllowStringAsInput()
+    {
+        var result = JSON.Transform(_testInput);
+        Assert.AreEqual("{\"FullName\":\"Veijo Frends\",\"Age\":30,\"StillBreething\":false}", result.Transformation);
+    }
 
-        [Test]
-        public void TransformMapsStringData()
-        {
-            var result = JSON.Transform(_testInput);
+    [Test]
+    public void TransformMapsStringData()
+    {
+        var result = JSON.Transform(_testInput);
 
-            var fullName = result.JToken["FullName"].Value<string>();
+        var fullName = result.JToken.FullName;
 
-            Assert.AreEqual("Veijo Frends", fullName);
-        }
+        Assert.AreEqual("Veijo Frends", fullName.ToString());
+    }
 
-        [Test]
-        public void TransformMapsNumbersCorrectly()
-        {
-            var result = JSON.Transform(_testInput);
+    [Test]
+    public void TransformMapsNumbersCorrectly()
+    {
+        var result = JSON.Transform(_testInput);
 
-            var age = result.JToken["Age"];
+        var age = result.JToken.Age;
 
-            Assert.AreEqual(JTokenType.Integer, age.Type);
-            Assert.AreEqual(30, age.Value<int>());
-        }
+        Assert.AreEqual(JTokenType.Integer, age.Type);
+        Assert.AreEqual(30, (int)age);
+    }
 
-        [Test]
-        public void TransformationMapsBoolValueCorrectly()
-        {
-            var result = JSON.Transform(_testInput);
+    [Test]
+    public void TransformationMapsBoolValueCorrectly()
+    {
+        var result = JSON.Transform(_testInput);
 
-            var breething = result.JToken["StillBreething"];
+        var breething = result.JToken.StillBreething;
 
-            Assert.AreEqual(JTokenType.Boolean, breething.Type);
-            Assert.AreEqual(false, breething.Value<bool>());
-        }
+        Assert.AreEqual(JTokenType.Boolean, breething.Type);
+        Assert.AreEqual(false, (bool)breething);
+    }
 
-        [Test]
-        public void TransformWorksWithArray()
-        {
-            _testInput.InputJson = @"{ ""array"": [{""key"":""first element""},{""key"":""second element""}]}";
-            _testInput.JsonMap = @"{""firstElement"":""#valueof($.array[0].key)""}";
+    [Test]
+    public void TransformWorksWithArray()
+    {
+        _testInput.InputJson = @"{ ""array"": [{""key"":""first element""},{""key"":""second element""}]}";
+        _testInput.JsonMap = @"{""firstElement"":""#valueof($.array[0].key)""}";
 
-            var result = JSON.Transform(_testInput);
-            var firstElement = result.JToken["firstElement"].Value<string>();
+        var result = JSON.Transform(_testInput);
+        var firstElement = result.JToken.firstElement;
 
-            Assert.AreEqual("first element", firstElement);
+        Assert.AreEqual("first element", (string)firstElement);
             
-        }
+    }
 
-        [Test]
-        public void TransformThrowsWithArrayRootElement()
-        {
-            _testInput.InputJson = @"[{""key"": ""first element""}, {""key"": ""second element""}]";
-            _testInput.JsonMap = @"{""firstElement"": ""#valueof($.[0].key)""}";
+    [Test]
+    public void TransformThrowsWithArrayRootElement()
+    {
+        _testInput.InputJson = @"[{""key"": ""first element""}, {""key"": ""second element""}]";
+        _testInput.JsonMap = @"{""firstElement"": ""#valueof($.[0].key)""}";
 
-            var ex = Assert.Throws<Exception>(() => JSON.Transform(_testInput));
-            Assert.That(ex.Message.Equals("Json transformation failed: Input Json is not valid: Array is not supported as root element."));
-        }
+        var ex = Assert.Throws<Exception>(() => JSON.Transform(_testInput));
+        Assert.That(ex.Message.Equals("Json transformation failed: Input Json is not valid: Array is not supported as root element."));
+    }
 
 
-        [Test]
-        public void InvalidJsonInputThrowsException()
-        {
-            _testInput.InputJson = @"{ foo baar";
+    [Test]
+    public void InvalidJsonInputThrowsException()
+    {
+        _testInput.InputJson = @"{ foo baar";
 
-            Assert.Throws<FormatException>(() => JSON.Transform(_testInput));
-        }
+        Assert.Throws<FormatException>(() => JSON.Transform(_testInput));
+    }
 
-        [Test]
-        public void InvalidJsonMapThrowsException()
-        {
-            _testInput.JsonMap = @"{""age"":""#valuof($.age)"", ""foo}";
+    [Test]
+    public void InvalidJsonMapThrowsException()
+    {
+        _testInput.JsonMap = @"{""age"":""#valuof($.age)"", ""foo}";
 
-            Assert.Throws<Exception>(() => JSON.Transform(_testInput));
-        }
+        Assert.Throws<Exception>(() => JSON.Transform(_testInput));
     }
 }
+

--- a/Frends.JSON.Transform/Frends.JSON.Transform/Definitions/Input.cs
+++ b/Frends.JSON.Transform/Frends.JSON.Transform/Definitions/Input.cs
@@ -11,14 +11,16 @@ namespace Frends.JSON.Transform.Definitions
         /// <summary>
         /// Map input json in String or JToken type
         /// </summary>
-        [DisplayFormat(DataFormatString = "Text")]
+        /// <example>{\"name\":\"veijo\"}</example>
+        [DisplayFormat(DataFormatString = "Json")]
         [DefaultValue("{\"name\":\"veijo\"}")]
         public object InputJson { get; set; }
 
         /// <summary>
         /// JUST json map. See: https://github.com/WorkMaze/JUST.net#just
         /// </summary>
-        [DisplayFormat(DataFormatString = "Text")]
+        /// <example>{\"firstName\":\"#valueof($.name)\"}</example>
+        [DisplayFormat(DataFormatString = "Json")]
         [DefaultValue("{\"firstName\":\"#valueof($.name)\"}")]
         public string JsonMap { get; set; }
     }

--- a/Frends.JSON.Transform/Frends.JSON.Transform/Definitions/Result.cs
+++ b/Frends.JSON.Transform/Frends.JSON.Transform/Definitions/Result.cs
@@ -12,12 +12,14 @@ namespace Frends.JSON.Transform.Definitions
         /// <summary>
         /// Transformation result as string
         /// </summary>
+        /// <example>"{\"firstName\":\"veijo\"}"</example>
         public string Transformation { get; private set; }
 
         /// <summary>
         /// Transformation result as JToken
         /// </summary>
-        public JToken JToken { get; private set; }
+        /// <example>{"firstName": "veijo"}</example>
+        public dynamic JToken { get; private set; }
 
         public Result(string transformationResult, JToken jToken)
         {

--- a/Frends.JSON.Transform/Frends.JSON.Transform/Frends.JSON.Transform.csproj
+++ b/Frends.JSON.Transform/Frends.JSON.Transform/Frends.JSON.Transform.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.JSON.Transform</AssemblyName>
 	  <RootNamespace>Frends.JSON.Transform</RootNamespace>
 
-	  <Version>1.0.0</Version>
+	  <Version>1.0.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.JSON.Transform/Frends.JSON.Transform/Frends.JSON.Transform.csproj
+++ b/Frends.JSON.Transform/Frends.JSON.Transform/Frends.JSON.Transform.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.JSON.Transform</AssemblyName>
 	  <RootNamespace>Frends.JSON.Transform</RootNamespace>
 
-	  <Version>1.0.1</Version>
+	  <Version>1.0.3</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>

--- a/Frends.JSON.Transform/Frends.JSON.Transform/Frends.JSON.Transform.csproj
+++ b/Frends.JSON.Transform/Frends.JSON.Transform/Frends.JSON.Transform.csproj
@@ -7,7 +7,7 @@
 	  <AssemblyName>Frends.JSON.Transform</AssemblyName>
 	  <RootNamespace>Frends.JSON.Transform</RootNamespace>
 
-	  <Version>1.0.3</Version>
+	  <Version>1.0.1</Version>
 	  <Authors>Frends</Authors>
 	  <Copyright>Frends</Copyright>
 	  <Company>Frends</Company>


### PR DESCRIPTION
#7 
- Changed the Result JToken to be dynamic to enable dot notation
- Changed input parameter field default DataFormatString to Json
- Updated documentation
- Fixed tests